### PR TITLE
Fix truncated workflows

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -9,9 +9,11 @@ on:
 jobs:
   hacs:
     name: HACS Action
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: actions/checkout@v2
       - name: HACS Action
-        uses: "hacs/action@main"
-        with:          category: "integration"
+        uses: hacs/action@main
+        with:
+          category: integration
+

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   validate:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     steps:
-      - uses: "actions/checkout@v2"      - uses: home-assistant/actions/hassfest@master
+      - uses: actions/checkout@v2
+      - uses: home-assistant/actions/hassfest@master
+

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,8 +16,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: 3.11
       - name: HACS validation
         uses: hacs/action@main
         with:
-          category: "integration"
+          category: integration
+


### PR DESCRIPTION
## Summary
- fix syntax for hacs workflow
- fix syntax for hassfest workflow
- set Python 3.11 in validate workflow

## Testing
- `pytest -q` *(fails: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_686d75ed9978832889ea9b539c2f27d4