### PR TITLE
Fix test imports and document running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,8 @@ tests:
 pip install homeassistant pytest-homeassistant-custom-component
 ```
 
-You can use the provided helper script to set everything up:
+You can use the provided helper script to set everything up. Ensure you are
+running **Python 3.11**, then run:
 
 ```bash
 bash scripts/setup_tests.sh

--- a/tests/test_coordinator_and_sensors.py
+++ b/tests/test_coordinator_and_sensors.py
@@ -1,7 +1,11 @@
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+# Add the custom_components directory to the path so the integration can be
+# imported directly as ``SmartHomeCopilot`` in tests.
+sys.path.append(
+    str(Path(__file__).resolve().parents[1] / "custom_components")
+)
 
 from datetime import datetime
 from unittest.mock import patch
@@ -15,7 +19,7 @@ from pytest_homeassistant_custom_component.common import (
     async_test_home_assistant,
 )
 
-from custom_components.SmartHomeCopilot.const import (
+from SmartHomeCopilot.const import (
     DOMAIN,
     CONF_PROVIDER,
     CONFIG_VERSION,
@@ -32,8 +36,8 @@ from custom_components.SmartHomeCopilot.const import (
     SENSOR_KEY_MODEL,
     SENSOR_KEY_LAST_ERROR,
 )
-from custom_components.SmartHomeCopilot.coordinator import AIAutomationCoordinator
-from custom_components.SmartHomeCopilot.sensor import (
+from SmartHomeCopilot.coordinator import AIAutomationCoordinator
+from SmartHomeCopilot.sensor import (
     SENSOR_DESCRIPTIONS,
     AISuggestionsSensor,
     AIProviderStatusSensor,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,11 @@
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+# Add the custom_components directory to the path so we can import the
+# integration directly as ``SmartHomeCopilot`` during tests.
+sys.path.append(
+    str(Path(__file__).resolve().parents[1] / "custom_components")
+)
 
 import pytest
 from unittest.mock import patch
@@ -14,7 +18,7 @@ from pytest_homeassistant_custom_component.common import (
     async_test_home_assistant,
 )
 
-from custom_components.SmartHomeCopilot.const import (
+from SmartHomeCopilot.const import (
     DOMAIN,
     CONF_PROVIDER,
     CONFIG_VERSION,


### PR DESCRIPTION
## Summary
- import the integration directly as `SmartHomeCopilot` in tests
- mention Python 3.11 when running the test setup script

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7e1414588328b4811df080e1d222