### PR TITLE
Fix docs and dashboard snippet

### DIFF
--- a/custom_components/README.md
+++ b/custom_components/README.md
@@ -35,8 +35,12 @@ An AI-powered Home Assistant custom integration that suggests automations based 
 1. In Home Assistant, go to **Overview** > **Edit Dashboard**.
 2. Click **Add Card** and choose **Manual**.
 3. Add the following configuration:
-4. To add another card:
-   type: 'custom:SmartHome-Copilot-card'
+
+```yaml
+type: 'custom:SmartHome-Copilot-card'
+```
+
+4. Make sure you've added the following resource:
 
 ```yaml
 type: module

--- a/custom_components/SmartHomeCopilot/README.md
+++ b/custom_components/SmartHomeCopilot/README.md
@@ -12,8 +12,8 @@ An AI-powered Home Assistant custom integration that suggests automations based 
 
 ## Installation
 
-1. Copy the `SmarHomeCopilot` folder to your `custom_components` directory.
-2. Copy the `ai-suggester-card.js` file to `www/SmarHomeCopilot/` directory.
+1. Copy the `SmartHomeCopilot` folder to your `custom_components` directory.
+2. Copy the `SmartHome-Copilot-card.js` file to `www/SmartHome_Copilot/` directory.
 3. Restart Home Assistant.
 4. In Home Assistant, navigate to **Configuration** > **Integrations**.
 5. Click the **Add Integration** button and search for **AI Suggester**.
@@ -38,9 +38,10 @@ An AI-powered Home Assistant custom integration that suggests automations based 
 3. Add the following configuration:
 
 ```yaml
-type: moduleurl: /local/SmarHomeCopilot/ai-suggester-card.js
+type: module
+url: /local/SmartHome_Copilot/SmartHome-Copilot-card.js
 ```
 
 4. To Add another card:
-   type: 'custom:ai-suggester-card'
+   type: 'custom:SmartHome-Copilot-card'
 

--- a/custom_components/dashboard/separate dashboard.txt
+++ b/custom_components/dashboard/separate dashboard.txt
@@ -54,7 +54,11 @@ views:
               state_attr('sensor.ai_automation_suggestions_google',
               'yaml_block') %}
 
-              {% if code %} ```yaml {{ code }} ``` {% else %} _No YAML block
-              found. The most recent AI reply did not contain raw code._ {%
-              endif %}
+              {% if code %}
+              ```yaml
+              {{ code }}
+              ```
+              {% else %}
+              _No YAML block found. The most recent AI reply did not contain raw code._
+              {% endif %}
 


### PR DESCRIPTION
## Summary
- fix typos in SmartHomeCopilot README
- clarify Lovelace card instructions
- close markdown snippet in dashboard
- sync instructions in integration README

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e57e5007c832893877db33b2cd441