### PR TITLE
Add Docker stack file for smartcopilot

### DIFF
--- a/docker-stack-smartcopilot.yml
+++ b/docker-stack-smartcopilot.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services:
+  # Home Assistant service
+  homeassistant:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    container_name: homeassistant
+    volumes:
+      - ha_config:/config  # Persist HA configuration
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - TZ=UTC
+    networks:
+      - ha-net
+    restart: unless-stopped
+
+  # SmartHomeCopilot service
+  smartcopilot:
+    image: ghcr.io/fjoelnr/smart-home-copilot:latest
+    container_name: smartcopilot
+    depends_on:
+      - homeassistant
+    environment:
+      - HASS_TOKEN=${HASS_TOKEN}       # Home Assistant long‑lived token
+      - OLLAMA_URL=${OLLAMA_URL}       # URL of your Ollama server
+      - OPENAI_API_KEY=${OPENAI_API_KEY}  # Optional OpenAI key
+    networks:
+      - ha-net
+    restart: unless-stopped
+
+networks:
+  ha-net: # Shared network for the stack
+    driver: bridge
+
+volumes:
+  ha_config: # Persisted Home Assistant data


### PR DESCRIPTION
## Summary
- provide `docker-stack-smartcopilot.yml` to run Home Assistant together with SmartHomeCopilot

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q` *(fails: Detected code that sets the time zone using set_time_zone instead of async_set_time_zone)*

------
https://chatgpt.com/codex/tasks/task_e_688147793e4c8328be03e99a894992f1