### PR TITLE
Add VSCode debug configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Remote Attach",
+            "type": "python",
+            "request": "attach",
+            "connect": {
+                "host": "raspberrypi",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "/config/custom_components/SmartHomeCopilot"
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "python.pythonPath": "/usr/bin/python3",
+    "debugpy.defaultPathMappings": [
+        {
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/config/custom_components/SmartHomeCopilot"
+        }
+    ]
+}

--- a/custom_components/SmartHomeCopilot/__init__.py
+++ b/custom_components/SmartHomeCopilot/__init__.py
@@ -1,4 +1,12 @@
-"""The AI Automation Suggester integration."""
+"""The AI Automation Suggester integration.
+
+To enable remote debugging with VS Code, add the following near startup::
+
+    import debugpy
+    debugpy.listen(("0.0.0.0", 5678))
+
+Then attach using the "Python: Remote Attach" launch configuration.
+"""
 
 import logging
 from homeassistant.config_entries import ConfigEntry


### PR DESCRIPTION
## Summary
- add VS Code remote debugging configuration
- document remote debug setup in code

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Detected code that sets the time zone using set_time_zone instead of async_set_time_zone)*

------
https://chatgpt.com/codex/tasks/task_e_6881477a49a48328aaf41b2ae3999959