### PR TITLE
Add example Home Assistant configs

### DIFF
--- a/ha_config/configuration.yaml
+++ b/ha_config/configuration.yaml
@@ -1,0 +1,8 @@
+# Sample Home Assistant configuration
+# Update the include path if you move these files or set $HACONFIG_DIR
+homeassistant:
+  packages: !include demo_devices.yaml
+
+smart_home_copilot:
+  # Provider credentials can be stored in secrets.yaml or via environment variables
+  # e.g. export OPENAI_API_KEY

--- a/ha_config/demo_devices.yaml
+++ b/ha_config/demo_devices.yaml
@@ -1,0 +1,19 @@
+# Example package with demo entities and an automation
+# Adjust entity names or add more devices if needed.
+light:
+  - platform: demo
+    name: Demo Lamp  # change name to customize entity_id
+
+sensor:
+  - platform: demo
+    name: Demo Temperature
+
+automation:
+  - alias: "Demo: turn on lamp at sunset"
+    trigger:
+      - platform: sun
+        event: sunset
+    action:
+      - service: light.turn_on
+        target:
+          entity_id: light.demo_lamp

--- a/ha_config/prompt_test.json
+++ b/ha_config/prompt_test.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Modify focus or devices as needed. Paths can reference env vars.",
+  "focus": "basic lighting automation",
+  "devices": ["light.demo_lamp", "sensor.demo_temperature"]
+}


### PR DESCRIPTION
## Summary
- add `ha_config` folder with demo config
- include example automation and demo entities
- add prompt test JSON

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q` *(fails: Lingering timer after job)*

------
https://chatgpt.com/codex/tasks/task_e_6881477b1e5c8328b22b930218a7b706