### PR TITLE
Add logs mount and restart policy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.watcherExclude": {
+        "**/logs/**": false
+    }
+}

--- a/docker-stack-smartcopilot.yml
+++ b/docker-stack-smartcopilot.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  smartcopilot:
+    image: smartcopilot:latest
+    volumes:
+      - ha_config:/config
+      - ha_config/logs:/config/logs
+    deploy:
+      restart_policy:
+        condition: on-failure
+
+volumes:
+  ha_config:


### PR DESCRIPTION
## Summary
- add docker stack with logs directory mount and restart policy for smartcopilot service
- configure VSCode watcher exclusion so logs folder updates are visible

## Testing
- `pytest -q` *(fails: RuntimeError about async_stop and time zone)*

------
https://chatgpt.com/codex/tasks/task_e_6881477da75c83289f13ee234b5d6fe8