### PR TITLE
Add debug guard block for module

### DIFF
--- a/custom_components/SmartHomeCopilot/__init__.py
+++ b/custom_components/SmartHomeCopilot/__init__.py
@@ -171,3 +171,15 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
     await async_unload_entry(hass, entry)
     await async_setup_entry(hass, entry)
+
+
+if __name__ == "__main__":
+    # Enable debugpy for hot-reload when running the module directly
+    import debugpy
+
+    debugpy.listen(("0.0.0.0", 5678))
+    debugpy.wait_for_client()
+
+    from custom_components.SmartHomeCopilot import main
+
+    main()


### PR DESCRIPTION
## Summary
- enable debugpy when running `__init__.py` directly

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Detected code that sets the time zone using set_time_zone instead of async_set_time_zone)*

------
https://chatgpt.com/codex/tasks/task_e_6881477f6ca08328bbdb86e0e586b45f