### PR TITLE
Add demo Smart Copilot config

### DIFF
--- a/ha_config/configuration.yaml
+++ b/ha_config/configuration.yaml
@@ -3,6 +3,11 @@
 homeassistant:
   packages: !include demo_devices.yaml
 
+# Enable Smart Copilot integration. This can also be toggled by setting the
+# environment variable ``SMARTCOPILOT_ENABLED`` to ``false``.
+smartcopilot:
+  enabled: true
+
 smart_home_copilot:
   # Provider credentials can be stored in secrets.yaml or via environment variables
   # e.g. export OPENAI_API_KEY

--- a/ha_config/demo_devices.yaml
+++ b/ha_config/demo_devices.yaml
@@ -1,18 +1,25 @@
-# Example package with demo entities and an automation
-# Adjust entity names or add more devices if needed.
+# Example package with demo entities and an automation triggered by the demo
+# binary sensor. Adjust names or add more entities as needed.
+
 light:
   - platform: demo
-    name: Demo Lamp  # change name to customize entity_id
+    name: Demo Lamp  # customize to change entity_id
+
+binary_sensor:
+  - platform: demo
+    name: Demo Motion  # example binary sensor
 
 sensor:
   - platform: demo
     name: Demo Temperature
 
 automation:
-  - alias: "Demo: turn on lamp at sunset"
+  # Turn the lamp on whenever the binary sensor reports "on"
+  - alias: "Demo: turn on lamp when motion detected"
     trigger:
-      - platform: sun
-        event: sunset
+      - platform: state
+        entity_id: binary_sensor.demo_motion
+        to: "on"
     action:
       - service: light.turn_on
         target:


### PR DESCRIPTION
## Summary
- add binary sensor automation to `demo_devices.yaml`
- enable SmartCopilot in sample `configuration.yaml`

## Testing
- `pytest -q` *(fails: RuntimeError: Event loop is closed)*

------
https://chatgpt.com/codex/tasks/task_e_688251cf36a48328a0eb1fcb4d632c60