### PR TITLE
Update VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,18 @@
 {
     "files.watcherExclude": {
         "**/logs/**": false
-    }
+    },
+    "python.pythonPath": "/usr/local/bin/python3",
+    "python.autoComplete.extraPaths": [
+        "/config/custom_components/SmartHomeCopilot"
+    ],
+    "remote.SSH.remotePlatform": {
+        "raspberrypi": "linux"
+    },
+    "debugpy.lenv.pathMappings": [
+        {
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "/config/custom_components/SmartHomeCopilot"
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- configure Python path and autocomplete settings
- set SSH remote platform
- add debugpy path mappings

## Testing
- `pytest -q` *(fails: RuntimeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_688251cd6b5c8328b2f563f206017503