### PR TITLE
Update image reference in docker stack

### DIFF
--- a/docker-stack-smartcopilot.yml
+++ b/docker-stack-smartcopilot.yml
@@ -22,7 +22,7 @@ services:
 
   # Container running the SmartCopilot integration
   smartcopilot:
-    image: smartcopilot:latest
+    image: ghcr.io/valurii/smarthomecopilot:latest
     volumes:
       - ha_config:/config            # share config with Home Assistant
       - ha_config/logs:/config/logs  # same log directory


### PR DESCRIPTION
## Summary
- use ghcr image for the `smartcopilot` service

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Lingering timer after job / RuntimeError: Event loop is closed)*

------
https://chatgpt.com/codex/tasks/task_e_68827b8183808328a9e250446e386135