### PR TITLE
Document environment variable use in configuration

### DIFF
--- a/ha_config/configuration.yaml
+++ b/ha_config/configuration.yaml
@@ -11,3 +11,7 @@ smartcopilot:
 smart_home_copilot:
   # Provider credentials can be stored in secrets.yaml or via environment variables
   # e.g. export OPENAI_API_KEY
+  # When using the provided Docker stack, set these environment variables
+  # so Home Assistant can reference them at startup.
+  openai_api_key: !env_var OPENAI_API_KEY
+  ollama_url: !env_var OLLAMA_URL


### PR DESCRIPTION
## Summary
- demonstrate referencing environment variables in `ha_config/configuration.yaml`
- add notes about using Docker stack variables

## Testing
- `pytest -q` *(fails: Detected code that sets the time zone using set_time_zone ...)*

------
https://chatgpt.com/codex/tasks/task_e_68827b7c50448328b20d0bb6d2a655a2