### PR TITLE
Remove deprecated smartcopilot config

### DIFF
--- a/ha_config/configuration.yaml
+++ b/ha_config/configuration.yaml
@@ -3,11 +3,6 @@
 homeassistant:
   packages: !include demo_devices.yaml
 
-# Enable Smart Copilot integration. This can also be toggled by setting the
-# environment variable ``SMARTCOPILOT_ENABLED`` to ``false``.
-smartcopilot:
-  enabled: true
-
 smart_home_copilot:
   # Provider credentials can be stored in secrets.yaml or via environment variables
   # e.g. export OPENAI_API_KEY


### PR DESCRIPTION
## Summary
- drop old `smartcopilot:` section from sample configuration

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q` *(fails: RuntimeError: Detected code that sets the time zone using set_time_zone instead of async_set_time_zone)*

------
https://chatgpt.com/codex/tasks/task_e_68829722723c832895b43f4f7676bc19