### PR TITLE
Allow overriding Home Assistant API URL

### DIFF
--- a/verify.sh
+++ b/verify.sh
@@ -2,12 +2,14 @@
 
 # Deploys a test stack and triggers the nightly automation.
 # Requires Docker and a valid $HASS_TOKEN for Home Assistant API access.
+# Optional environment variable:
+#   HASS_API - Base URL for the Home Assistant API (default: http://localhost:8123/api/)
 
 set -euo pipefail
 
 STACK_NAME="smartcopilot_test"
 STACK_FILE="docker-stack-smartcopilot.yml"
-HASS_API="http://localhost:8123/api/"
+HASS_API="${HASS_API:-http://localhost:8123/api/}"
 
 # Deploy the stack
 if ! docker stack deploy -c "$STACK_FILE" "$STACK_NAME"; then


### PR DESCRIPTION
## Summary
- allow overriding the API base URL in `verify.sh`
- document the `HASS_API` env var

## Testing
- `bash -n verify.sh`
- `pytest -q` *(fails: `RuntimeError: Detected code that sets the time zone using set_time_zone`)*

------
https://chatgpt.com/codex/tasks/task_e_68829732e5c08328baace171822dc10e