### PR TITLE
Add verify.sh usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,19 @@ bash scripts/setup_tests.sh
 pytest -q
 ```
 
+### Running `verify.sh`
+
+Use the `verify.sh` script for a quick end‑to‑end check of the docker stack. It
+deploys `docker-stack-smartcopilot.yml`, triggers the nightly automation, and
+tears everything down again. You need **Docker** and a valid
+`HASS_TOKEN` (a long‑lived access token from Home Assistant).
+
+```bash
+export HASS_TOKEN="your-token"
+./verify.sh
+```
+
+
 ---
 
 ## Disclaimer


### PR DESCRIPTION
## Summary
- document running `verify.sh` for stack checks

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q` *(fails: RuntimeError – Detected code that sets the time zone using set_time_zone)*

------
https://chatgpt.com/codex/tasks/task_e_68829734826483289c695fbf06a6ad63