### PR TITLE
CI‑Setup, interaktive UI & sichere Credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install homeassistant==2024.6.2 pytest pytest-homeassistant-custom-component pyyaml voluptuous openai anthropic aiohttp
+      - name: Run hassfest validation
+        run: |
+          hassfest
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -179,11 +179,13 @@ Reference these variables in `configuration.yaml` so Home Assistant loads them a
 
 ```yaml
 smart_home_copilot:
-  openai_api_key: !env_var OPENAI_API_KEY
+openai_api_key: !env_var OPENAI_API_KEY
   ollama_url: !env_var OLLAMA_URL
 ```
 
 Removing one of these variables disables that provider, letting you run purely local or cloud based models.
+
+When these environment variables are present, the integration setup form automatically pre-fills the corresponding API key fields so credentials never need to be typed into the UI.
 
 ---
 

--- a/custom_components/SmartHomeCopilot/config_flow.py
+++ b/custom_components/SmartHomeCopilot/config_flow.py
@@ -2,6 +2,8 @@
 """Config flow for AI Automation Suggester."""
 from __future__ import annotations
 
+import os
+
 import logging
 from typing import Any, Dict, Optional
 
@@ -69,6 +71,25 @@ from .const import (  # noqa: E501  (long import list)
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+ENV_VARS = {
+    CONF_OPENAI_API_KEY: "OPENAI_API_KEY",
+    CONF_ANTHROPIC_API_KEY: "ANTHROPIC_API_KEY",
+    CONF_GOOGLE_API_KEY: "GOOGLE_API_KEY",
+    CONF_GROQ_API_KEY: "GROQ_API_KEY",
+    CONF_CUSTOM_OPENAI_API_KEY: "CUSTOM_OPENAI_API_KEY",
+    CONF_MISTRAL_API_KEY: "MISTRAL_API_KEY",
+    CONF_PERPLEXITY_API_KEY: "PERPLEXITY_API_KEY",
+    CONF_OPENROUTER_API_KEY: "OPENROUTER_API_KEY",
+    CONF_OPENAI_AZURE_API_KEY: "OPENAI_AZURE_API_KEY",
+}
+
+
+def _env_default(key: str) -> str | None:
+    """Return default value from environment variables if present."""
+    env = ENV_VARS.get(key)
+    return os.getenv(env) if env else None
 
 
 # ─────────────────────────────────────────────────────────────
@@ -303,9 +324,10 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_openai(self, user_input=None):
         schema = {
-            vol.Required(CONF_OPENAI_API_KEY): TextSelector(
-                TextSelectorConfig(type="password")
-            ),
+            vol.Required(
+                CONF_OPENAI_API_KEY,
+                default=_env_default(CONF_OPENAI_API_KEY),
+            ): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_OPENAI_MODEL, default=DEFAULT_MODELS["OpenAI"]): str,
             vol.Optional(CONF_OPENAI_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(
                 vol.Coerce(float), vol.Range(min=0.0, max=2.0)
@@ -330,9 +352,10 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         schema = {
-            vol.Required(CONF_ANTHROPIC_API_KEY): TextSelector(
-                TextSelectorConfig(type="password")
-            ),
+            vol.Required(
+                CONF_ANTHROPIC_API_KEY,
+                default=_env_default(CONF_ANTHROPIC_API_KEY),
+            ): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(
                 CONF_ANTHROPIC_MODEL, default=DEFAULT_MODELS["Anthropic"]
             ): str,
@@ -359,9 +382,10 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         schema = {
-            vol.Required(CONF_GOOGLE_API_KEY): TextSelector(
-                TextSelectorConfig(type="password")
-            ),
+            vol.Required(
+                CONF_GOOGLE_API_KEY,
+                default=_env_default(CONF_GOOGLE_API_KEY),
+            ): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_GOOGLE_MODEL, default=DEFAULT_MODELS["Google"]): str,
             vol.Optional(CONF_GOOGLE_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(
                 vol.Coerce(float), vol.Range(min=0.0, max=2.0)
@@ -380,9 +404,10 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_groq(self, user_input=None):
         schema = {
-            vol.Required(CONF_GROQ_API_KEY): TextSelector(
-                TextSelectorConfig(type="password")
-            ),
+            vol.Required(
+                CONF_GROQ_API_KEY,
+                default=_env_default(CONF_GROQ_API_KEY),
+            ): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_GROQ_MODEL, default=DEFAULT_MODELS["Groq"]): str,
             vol.Optional(CONF_GROQ_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(
                 vol.Coerce(float), vol.Range(min=0.0, max=2.0)
@@ -462,9 +487,10 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = {
             vol.Required(CONF_CUSTOM_OPENAI_ENDPOINT): str,
-            vol.Optional(CONF_CUSTOM_OPENAI_API_KEY): TextSelector(
-                TextSelectorConfig(type="password")
-            ),
+            vol.Optional(
+                CONF_CUSTOM_OPENAI_API_KEY,
+                default=_env_default(CONF_CUSTOM_OPENAI_API_KEY),
+            ): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(
                 CONF_CUSTOM_OPENAI_MODEL, default=DEFAULT_MODELS["Custom OpenAI"]
             ): str,
@@ -492,9 +518,10 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         schema = {
-            vol.Required(CONF_MISTRAL_API_KEY): TextSelector(
-                TextSelectorConfig(type="password")
-            ),
+            vol.Required(
+                CONF_MISTRAL_API_KEY,
+                default=_env_default(CONF_MISTRAL_API_KEY),
+            ): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(CONF_MISTRAL_MODEL, default=DEFAULT_MODELS["Mistral AI"]): str,
             vol.Optional(
                 CONF_MISTRAL_TEMPERATURE, default=DEFAULT_TEMPERATURE
@@ -511,9 +538,10 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         schema = {
-            vol.Required(CONF_PERPLEXITY_API_KEY): TextSelector(
-                TextSelectorConfig(type="password")
-            ),
+            vol.Required(
+                CONF_PERPLEXITY_API_KEY,
+                default=_env_default(CONF_PERPLEXITY_API_KEY),
+            ): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(
                 CONF_PERPLEXITY_MODEL, default=DEFAULT_MODELS["Perplexity AI"]
             ): str,
@@ -540,9 +568,10 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         schema = {
-            vol.Required(CONF_OPENROUTER_API_KEY): TextSelector(
-                TextSelectorConfig(type="password")
-            ),
+            vol.Required(
+                CONF_OPENROUTER_API_KEY,
+                default=_env_default(CONF_OPENROUTER_API_KEY),
+            ): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(
                 CONF_OPENROUTER_MODEL, default=DEFAULT_MODELS["OpenRouter"]
             ): str,
@@ -575,9 +604,10 @@ class AIAutomationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return None
 
         schema = {
-            vol.Required(CONF_OPENAI_AZURE_API_KEY): TextSelector(
-                TextSelectorConfig(type="password")
-            ),
+            vol.Required(
+                CONF_OPENAI_AZURE_API_KEY,
+                default=_env_default(CONF_OPENAI_AZURE_API_KEY),
+            ): TextSelector(TextSelectorConfig(type="password")),
             vol.Optional(
                 CONF_OPENAI_AZURE_DEPLOYMENT_ID, default=DEFAULT_MODELS["OpenAI Azure"]
             ): str,
@@ -660,7 +690,11 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
         if provider == "OpenAI":
             schema[
                 vol.Optional(
-                    CONF_OPENAI_API_KEY, default=self._get_option(CONF_OPENAI_API_KEY)
+                    CONF_OPENAI_API_KEY,
+                    default=self._get_option(
+                        CONF_OPENAI_API_KEY,
+                        _env_default(CONF_OPENAI_API_KEY),
+                    ),
                 )
             ] = TextSelector(TextSelectorConfig(type="password"))
             schema[
@@ -683,7 +717,10 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             schema[
                 vol.Optional(
                     CONF_ANTHROPIC_API_KEY,
-                    default=self._get_option(CONF_ANTHROPIC_API_KEY),
+                    default=self._get_option(
+                        CONF_ANTHROPIC_API_KEY,
+                        _env_default(CONF_ANTHROPIC_API_KEY),
+                    ),
                 )
             ] = TextSelector(TextSelectorConfig(type="password"))
             schema[
@@ -705,7 +742,11 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
         elif provider == "Google":
             schema[
                 vol.Optional(
-                    CONF_GOOGLE_API_KEY, default=self._get_option(CONF_GOOGLE_API_KEY)
+                    CONF_GOOGLE_API_KEY,
+                    default=self._get_option(
+                        CONF_GOOGLE_API_KEY,
+                        _env_default(CONF_GOOGLE_API_KEY),
+                    ),
                 )
             ] = TextSelector(TextSelectorConfig(type="password"))
             schema[
@@ -727,7 +768,11 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
         elif provider == "Groq":
             schema[
                 vol.Optional(
-                    CONF_GROQ_API_KEY, default=self._get_option(CONF_GROQ_API_KEY)
+                    CONF_GROQ_API_KEY,
+                    default=self._get_option(
+                        CONF_GROQ_API_KEY,
+                        _env_default(CONF_GROQ_API_KEY),
+                    ),
                 )
             ] = TextSelector(TextSelectorConfig(type="password"))
             schema[
@@ -828,7 +873,10 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             schema[
                 vol.Optional(
                     CONF_CUSTOM_OPENAI_API_KEY,
-                    default=self._get_option(CONF_CUSTOM_OPENAI_API_KEY),
+                    default=self._get_option(
+                        CONF_CUSTOM_OPENAI_API_KEY,
+                        _env_default(CONF_CUSTOM_OPENAI_API_KEY),
+                    ),
                 )
             ] = TextSelector(TextSelectorConfig(type="password"))
             schema[
@@ -850,7 +898,11 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
         elif provider == "Mistral AI":
             schema[
                 vol.Optional(
-                    CONF_MISTRAL_API_KEY, default=self._get_option(CONF_MISTRAL_API_KEY)
+                    CONF_MISTRAL_API_KEY,
+                    default=self._get_option(
+                        CONF_MISTRAL_API_KEY,
+                        _env_default(CONF_MISTRAL_API_KEY),
+                    ),
                 )
             ] = TextSelector(TextSelectorConfig(type="password"))
             schema[
@@ -873,7 +925,10 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             schema[
                 vol.Optional(
                     CONF_PERPLEXITY_API_KEY,
-                    default=self._get_option(CONF_PERPLEXITY_API_KEY),
+                    default=self._get_option(
+                        CONF_PERPLEXITY_API_KEY,
+                        _env_default(CONF_PERPLEXITY_API_KEY),
+                    ),
                 )
             ] = TextSelector(TextSelectorConfig(type="password"))
             schema[
@@ -896,7 +951,10 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             schema[
                 vol.Optional(
                     CONF_OPENROUTER_API_KEY,
-                    default=self._get_option(CONF_OPENROUTER_API_KEY),
+                    default=self._get_option(
+                        CONF_OPENROUTER_API_KEY,
+                        _env_default(CONF_OPENROUTER_API_KEY),
+                    ),
                 )
             ] = TextSelector(TextSelectorConfig(type="password"))
             schema[
@@ -925,7 +983,10 @@ class AIAutomationOptionsFlowHandler(config_entries.OptionsFlow):
             schema[
                 vol.Optional(
                     CONF_OPENAI_AZURE_API_KEY,
-                    default=self._get_option(CONF_OPENAI_AZURE_API_KEY),
+                    default=self._get_option(
+                        CONF_OPENAI_AZURE_API_KEY,
+                        _env_default(CONF_OPENAI_AZURE_API_KEY),
+                    ),
                 )
             ] = TextSelector(TextSelectorConfig(type="password"))
             schema[

--- a/custom_components/dashboard/__init__.py
+++ b/custom_components/dashboard/__init__.py
@@ -1,0 +1,57 @@
+"""Simple API backend for the SmartHome Copilot dashboard card."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.components.http import HomeAssistantView
+
+from ..SmartHomeCopilot.const import DOMAIN as COPILOT_DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
+    """Register API views used by the dashboard."""
+    hass.http.register_view(CopilotSuggestionsView)
+    hass.http.register_view(CopilotActionView)
+    return True
+
+
+class CopilotSuggestionsView(HomeAssistantView):
+    """Expose generated suggestions via REST."""
+
+    url = "/api/SmartHome_Copilot/suggestions"
+    name = "SmartHomeCopilotSuggestions"
+    requires_auth = False
+
+    async def get(self, request):
+        hass = request.app["hass"]
+        suggestions = []
+        for coordinator in hass.data.get(COPILOT_DOMAIN, {}).values():
+            data = getattr(coordinator, "data", {})
+            if data.get("yaml_block"):
+                suggestions.append(
+                    {
+                        "id": 0,
+                        "title": "Automation Suggestion",
+                        "shortDescription": data.get("description"),
+                        "detailedDescription": data.get("description"),
+                        "yamlCode": data.get("yaml_block"),
+                        "showDetails": False,
+                    }
+                )
+        return self.json(suggestions)
+
+
+class CopilotActionView(HomeAssistantView):
+    """Dummy endpoint for accept/decline actions."""
+
+    url = "/api/SmartHome_Copilot/{action}/{suggestion_id}"
+    name = "SmartHomeCopilotAction"
+    requires_auth = False
+
+    async def post(self, request, action, suggestion_id):
+        _LOGGER.debug("Received %s for suggestion %s", action, suggestion_id)
+        return self.json({"success": True})

--- a/custom_components/dashboard/manifest.json
+++ b/custom_components/dashboard/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "dashboard",
+  "name": "SmartHomeCopilot Dashboard",
+  "documentation": "https://github.com/fjoelnr/SmartHomeCopilot",
+  "version": "1.0.0",
+  "requirements": [],
+  "dependencies": ["smart_home_copilot"],
+  "codeowners": ["@fjoelnr"]
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow
- create simple dashboard API integration
- read API keys from env vars automatically
- document env variable prefill

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q` *(fails: Lingering timer after job)*

------
https://chatgpt.com/codex/tasks/task_e_6884ccf0ca888328981e6511914eb154