### PR TITLE
Support multiple suggestions

### DIFF
--- a/custom_components/SmartHomeCopilot/sensor.py
+++ b/custom_components/SmartHomeCopilot/sensor.py
@@ -237,9 +237,7 @@ class AISuggestionsSensor(AIBaseSensor):
         # Initialize state with default values
         self._attr_native_value = "No Suggestions"
         self._attr_extra_state_attributes = {
-            "suggestions": "No suggestions yet",
-            "description": None,
-            "yaml_block": None,
+            "suggestions": [],
             "last_update": None,
             "entities_processed": [],
             "provider": self._entry.data.get(CONF_PROVIDER, "unknown"),
@@ -257,13 +255,10 @@ class AISuggestionsSensor(AIBaseSensor):
     def _update_state_and_attributes(self) -> None:
         """Update sensor state and attributes."""
         data = self.coordinator.data or {}
-        suggestions = data.get("suggestions")
+        suggestions = data.get("suggestions", [])
         last_update_timestamp = data.get("last_update")
 
-        if suggestions and suggestions not in (
-            "No suggestions available",
-            "No suggestions yet",
-        ):
+        if suggestions:
             if last_update_timestamp and (
                 self._previous_suggestions_timestamp is None
                 or last_update_timestamp > self._previous_suggestions_timestamp
@@ -277,8 +272,6 @@ class AISuggestionsSensor(AIBaseSensor):
 
         self._attr_extra_state_attributes = {
             "suggestions": suggestions,
-            "description": data.get("description"),
-            "yaml_block": data.get("yaml_block"),
             "last_update": data.get("last_update"),
             "entities_processed": data.get("entities_processed", []),
             "provider": self._entry.data.get(CONF_PROVIDER, "unknown"),

--- a/tests/test_coordinator_and_sensors.py
+++ b/tests/test_coordinator_and_sensors.py
@@ -58,7 +58,7 @@ async def test_coordinator_budgets():
     }
     with patch("homeassistant.util.dt.get_time_zone", return_value=ZoneInfo("UTC")):
         async with async_test_home_assistant(**kwargs) as hass:
-            hass.config.set_time_zone("UTC")
+            await hass.config.async_set_time_zone("UTC")
             hass.data.pop(LOADER_CUSTOM, None)
             entry = MockConfigEntry(
                 domain=DOMAIN,
@@ -105,7 +105,7 @@ async def test_sensor_updates():
     }
     with patch("homeassistant.util.dt.get_time_zone", return_value=ZoneInfo("UTC")):
         async with async_test_home_assistant(**kwargs) as hass:
-            hass.config.set_time_zone("UTC")
+            await hass.config.async_set_time_zone("UTC")
             hass.data.pop(LOADER_CUSTOM, None)
             entry = MockConfigEntry(
                 domain=DOMAIN,
@@ -144,9 +144,9 @@ async def test_sensor_updates():
 
         now = datetime.now()
         new_data = {
-            "suggestions": "try this",
-            "description": "desc",
-            "yaml_block": "yaml",
+            "suggestions": [
+                {"title": "t", "description": "desc", "yaml": "yaml"}
+            ],
             "last_update": now,
             "entities_processed": ["sensor.test"],
             "provider": "OpenAI",
@@ -159,6 +159,7 @@ async def test_sensor_updates():
 
         assert sugg.native_value == "New Suggestions Available"
         assert sugg.extra_state_attributes["entities_processed_count"] == 1
+        assert sugg.extra_state_attributes["suggestions"] == new_data["suggestions"]
         assert status.native_value == PROVIDER_STATUS_CONNECTED
         assert err.native_value == "No Error"
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -37,7 +37,7 @@ async def test_async_setup_entry(expected_lingering_timers):
     }
     with patch("homeassistant.util.dt.get_time_zone", return_value=ZoneInfo("UTC")):
         async with async_test_home_assistant(**kwargs) as hass:
-            hass.config.set_time_zone("UTC")
+            await hass.config.async_set_time_zone("UTC")
             hass.data.pop(LOADER_CUSTOM, None)
             entry = MockConfigEntry(
                 domain=DOMAIN,


### PR DESCRIPTION
## Summary
- parse all YAML blocks from provider responses in `AIAutomationCoordinator`
- track suggestions as list and update sensors
- provide unique IDs in dashboard API and remove individual suggestions on accept/decline
- fix tests for new structure

## Testing
- `bash scripts/setup_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68860fbc2d5c8328a90913f530250fe8