### PR TITLE
Add i18n with German translations

### DIFF
--- a/custom_components/smart_home_copilot/sensor.py
+++ b/custom_components/smart_home_copilot/sensor.py
@@ -74,18 +74,18 @@ PROVIDER_TO_MODEL_KEY_MAP: dict[str, str] = {
 SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key=SENSOR_KEY_SUGGESTIONS,
-        name="AI Automation Suggestions",
+        translation_key="ai_automation_suggestions",
         icon="mdi:robot-happy-outline",
     ),
     SensorEntityDescription(
         key=SENSOR_KEY_STATUS,
-        name="AI Provider Status",
+        translation_key="ai_provider_status",
         icon="mdi:lan-check",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key=SENSOR_KEY_INPUT_TOKENS,
-        name="Max Input Tokens",
+        translation_key="max_input_tokens",
         icon="mdi:format-letter-starts-with",
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement="tokens",
@@ -93,7 +93,7 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     ),
     SensorEntityDescription(
         key=SENSOR_KEY_OUTPUT_TOKENS,
-        name="Max Output Tokens",
+        translation_key="max_output_tokens",
         icon="mdi:format-letter-ends-with",
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement="tokens",
@@ -101,13 +101,13 @@ SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     ),
     SensorEntityDescription(
         key=SENSOR_KEY_MODEL,
-        name="AI Model In Use",
+        translation_key="ai_model_in_use",
         icon="mdi:brain",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key=SENSOR_KEY_LAST_ERROR,
-        name="Last Error Message",
+        translation_key="last_error_message",
         icon="mdi:alert-circle-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
@@ -125,10 +125,10 @@ async def async_setup_entry(
 
     entities: list[SensorEntity] = []
     for description in SENSOR_DESCRIPTIONS:
-        formatted_name = f"{description.name} ({provider_name})"
         specific_description = SensorEntityDescription(
             key=description.key,
-            name=formatted_name,
+            translation_key=description.translation_key,
+            translation_placeholders={"provider": provider_name},
             icon=description.icon,
             entity_category=description.entity_category,
             native_unit_of_measurement=description.native_unit_of_measurement,

--- a/custom_components/smart_home_copilot/strings.json
+++ b/custom_components/smart_home_copilot/strings.json
@@ -229,5 +229,27 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "ai_automation_suggestions": {
+        "name": "AI Automation Suggestions ({provider})"
+      },
+      "ai_provider_status": {
+        "name": "AI Provider Status ({provider})"
+      },
+      "max_input_tokens": {
+        "name": "Max Input Tokens ({provider})"
+      },
+      "max_output_tokens": {
+        "name": "Max Output Tokens ({provider})"
+      },
+      "ai_model_in_use": {
+        "name": "AI Model In Use ({provider})"
+      },
+      "last_error_message": {
+        "name": "Last Error Message ({provider})"
+      }
+    }
   }
 }

--- a/custom_components/smart_home_copilot/translations/de.json
+++ b/custom_components/smart_home_copilot/translations/de.json
@@ -229,4 +229,27 @@
         }
       }
     }
-  }}
+  },
+  "entity": {
+    "sensor": {
+      "ai_automation_suggestions": {
+        "name": "KI-Automatisierungsvorschläge ({provider})"
+      },
+      "ai_provider_status": {
+        "name": "KI-Anbieterstatus ({provider})"
+      },
+      "max_input_tokens": {
+        "name": "Maximale Eingabe-Tokens ({provider})"
+      },
+      "max_output_tokens": {
+        "name": "Maximale Ausgabe-Tokens ({provider})"
+      },
+      "ai_model_in_use": {
+        "name": "Verwendetes KI-Modell ({provider})"
+      },
+      "last_error_message": {
+        "name": "Letzte Fehlermeldung ({provider})"
+      }
+    }
+  }
+}

--- a/custom_components/smart_home_copilot/translations/en.json
+++ b/custom_components/smart_home_copilot/translations/en.json
@@ -229,4 +229,27 @@
         }
       }
     }
-  }}
+  },
+  "entity": {
+    "sensor": {
+      "ai_automation_suggestions": {
+        "name": "AI Automation Suggestions ({provider})"
+      },
+      "ai_provider_status": {
+        "name": "AI Provider Status ({provider})"
+      },
+      "max_input_tokens": {
+        "name": "Max Input Tokens ({provider})"
+      },
+      "max_output_tokens": {
+        "name": "Max Output Tokens ({provider})"
+      },
+      "ai_model_in_use": {
+        "name": "AI Model In Use ({provider})"
+      },
+      "last_error_message": {
+        "name": "Last Error Message ({provider})"
+      }
+    }
+  }
+}

--- a/custom_components/smart_home_copilot/www/SmartHome_Copilot/SmartHome-Copilot-card.js
+++ b/custom_components/smart_home_copilot/www/SmartHome_Copilot/SmartHome-Copilot-card.js
@@ -40,6 +40,36 @@ export class SmartHomeCopilotCard extends LitElement {
   @property({ type: Array }) suggestions = [];
   @state() loading = true;
   @state() error = null;
+
+  static LOCALIZED_STRINGS = {
+    en: {
+      title: 'AI Automation Suggestions',
+      loading: 'Loading suggestions...',
+      details: 'Details',
+      copyYaml: 'Copy YAML',
+      accept: 'Accept',
+      decline: 'Decline',
+      copied: 'YAML code copied to clipboard!',
+      fetchError: 'Failed to fetch suggestions.',
+      errorPrefix: 'Error: '
+    },
+    de: {
+      title: 'KI-Automatisierungsvorschläge',
+      loading: 'Vorschläge werden geladen...',
+      details: 'Details',
+      copyYaml: 'YAML kopieren',
+      accept: 'Annehmen',
+      decline: 'Ablehnen',
+      copied: 'YAML-Code in die Zwischenablage kopiert!',
+      fetchError: 'Fehler beim Abrufen der Vorschläge.',
+      errorPrefix: 'Fehler: '
+    }
+  };
+
+  get strings() {
+    const lang = (this.hass?.language || 'en').split('-')[0];
+    return SmartHomeCopilotCard.LOCALIZED_STRINGS[lang] || SmartHomeCopilotCard.LOCALIZED_STRINGS.en;
+  }
   connectedCallback() {
     super.connectedCallback();
     this.fetchData();
@@ -51,7 +81,7 @@ export class SmartHomeCopilotCard extends LitElement {
       const response = await this.hass.callApi('GET', '/api/SmartHome_Copilot/suggestions');
       this.suggestions = response;
     } catch (err) {
-      this.error = err.message || 'Failed to fetch suggestions.';
+      this.error = err.message || this.strings.fetchError;
     } finally {
       this.loading = false;
     }
@@ -65,7 +95,7 @@ export class SmartHomeCopilotCard extends LitElement {
     this.dispatchEvent(new CustomEvent('hass-notification', {
       detail: {
         type: 'info',
-        message: 'YAML code copied to clipboard!',
+        message: this.strings.copied,
       },
     }));
   }
@@ -85,24 +115,24 @@ export class SmartHomeCopilotCard extends LitElement {
     return html`
       <ha-card>
         <div>
-          <h2>AI Automation Suggestions</h2>
+          <h2>${this.strings.title}</h2>
           ${this.loading
-            ? html`<p>Loading suggestions...</p>`
+            ? html`<p>${this.strings.loading}</p>`
             : this.error
-              ? html`<p class="error">Error: ${this.error}</p>`
+              ? html`<p class="error">${this.strings.errorPrefix}${this.error}</p>`
               : html`
                   <ul>
                     ${this.suggestions.map(suggestion => html`
                       <li>
                         <h3>${suggestion.title}</h3>
                         <p>${suggestion.shortDescription}</p>
-                        <button @click="${() => this.toggleDetails(suggestion)}">Details</button>
+                        <button @click="${() => this.toggleDetails(suggestion)}">${this.strings.details}</button>
                         <div class="details" ?open="${suggestion.showDetails}">
                           <p>${suggestion.detailedDescription}</p>
                           <pre><code class="language-yaml">${suggestion.yamlCode}</code></pre>
-                          <button @click="${() => this.copyYaml(suggestion.yamlCode)}">Copy YAML</button>
-                          <button @click="${() => this.handleSuggestionAction(suggestion.id, 'accept')}">Accept</button>
-                          <button @click="${() => this.handleSuggestionAction(suggestion.id, 'decline')}">Decline</button>
+                          <button @click="${() => this.copyYaml(suggestion.yamlCode)}">${this.strings.copyYaml}</button>
+                          <button @click="${() => this.handleSuggestionAction(suggestion.id, 'accept')}">${this.strings.accept}</button>
+                          <button @click="${() => this.handleSuggestionAction(suggestion.id, 'decline')}">${this.strings.decline}</button>
                         </div>
                       </li>
                     `)}


### PR DESCRIPTION
## Summary
- translate sensor names and use translation placeholders
- provide German and English entity translations
- add language-based strings to the Lovelace card

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688678435cdc8328be7a13938a5df794