### PR TITLE
Add credentials.yaml.example and update .gitignore to protect secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,16 @@ dist/
 *.egg-info/
 
 # Virtual environments
-.env
 .venv
 env/
 venv/
 
 # Home Assistant custom integration secrets
-custom_components/smarthomecopilot/credentials.yaml
+custom_components/smart_home_copilot/credentials.yaml
+
+# Root credentials file
+credentials.yaml
+
+# Other common secret files
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ Removing one of these variables disables that provider, letting you run purely l
 
 When these environment variables are present, the integration setup form automatically pre-fills the corresponding API key fields so credentials never need to be typed into the UI.
 
+### `credentials.yaml`
+
+As an alternative to environment variables you can keep your API keys in a file. Copy `credentials.yaml.example` to `credentials.yaml` and enter your secrets there. The file is ignored by Git so your keys stay private. When using Docker, mount this file into the container:
+
+```yaml
+services:
+  homeassistant:
+    volumes:
+      - ./credentials.yaml:/config/credentials.yaml:ro
+```
+
+Either approach works – use whichever fits your setup best.
+
 ---
 
 ## 🛠️ Advanced Configuration

--- a/credentials.yaml.example
+++ b/credentials.yaml.example
@@ -1,0 +1,12 @@
+# Beispiel-Konfig für SmartHomeCopilot Credentials
+OPENAI_API_KEY: "sk-XXXX..."
+ANTHROPIC_API_KEY: "test-key-abc..."
+OLLAMA_URL: "http://localhost:11434"
+HASS_TOKEN: "abcdef1234567890"
+# Optional weitere Keys
+GOOGLE_API_KEY: ""
+GROQ_API_KEY: ""
+CUSTOM_OPENAI_API_KEY: ""
+MISTRAL_API_KEY: ""
+PERPLEXITY_API_KEY: ""
+OPENROUTER_API_KEY: ""


### PR DESCRIPTION
## Summary
- provide a repository wide `credentials.yaml.example`
- ignore `credentials.yaml` and other common secret files
- document how to use `credentials.yaml` for Docker setups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68867b298c4c8328945c8f89526400b9