### PR TITLE
Add provider info and refresh to card

### DIFF
--- a/custom_components/shc_dashboard/__init__.py
+++ b/custom_components/shc_dashboard/__init__.py
@@ -49,6 +49,7 @@ class CopilotSuggestionsView(HomeAssistantView):
                         "shortDescription": sug.get("description"),
                         "detailedDescription": sug.get("description"),
                         "yamlCode": sug.get("yaml"),
+                        "provider": sug.get("provider", data.get("provider")),
                         "showDetails": False,
                     }
                 )

--- a/custom_components/smart_home_copilot/coordinator.py
+++ b/custom_components/smart_home_copilot/coordinator.py
@@ -241,6 +241,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                             "title": "Automation Suggestion",
                             "description": description,
                             "yaml": yaml_block.strip(),
+                            "provider": self._opt(CONF_PROVIDER, "unknown"),
                         }
                     )
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -101,6 +101,7 @@ async def test_accept_logic_writes_file(tmp_path):
                     "title": "t",
                     "description": "desc",
                     "yaml": "- id: 'a'\n  alias: t\n  trigger: []\n  action: []\n",
+                    "provider": "OpenAI",
                 }
             ]
         }

--- a/tests/test_coordinator_and_sensors.py
+++ b/tests/test_coordinator_and_sensors.py
@@ -145,7 +145,7 @@ async def test_sensor_updates():
         now = datetime.now()
         new_data = {
             "suggestions": [
-                {"title": "t", "description": "desc", "yaml": "yaml"}
+                {"title": "t", "description": "desc", "yaml": "yaml", "provider": "OpenAI"}
             ],
             "last_update": now,
             "entities_processed": ["sensor.test"],


### PR DESCRIPTION
## Summary
- support custom title on the dashboard card
- include provider info in each suggestion
- add refresh button and localized strings for it
- adjust tests for the new provider field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b7b02e4c8328a5034cffa63d3435