### PR TITLE
Persist AI suggestions

### DIFF
--- a/custom_components/shc_dashboard/__init__.py
+++ b/custom_components/shc_dashboard/__init__.py
@@ -125,5 +125,6 @@ class CopilotActionView(HomeAssistantView):
         suggestions.pop(idx)
         coordinator.data.update({"suggestions": suggestions})
         coordinator.async_set_updated_data(coordinator.data)
+        await coordinator._async_save_suggestions()
 
         return self.json({"success": True})

--- a/custom_components/smart_home_copilot/coordinator.py
+++ b/custom_components/smart_home_copilot/coordinator.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import (
     entity_registry as er,
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (  # noqa: E501
@@ -135,6 +136,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
 
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=None)
         self.session = async_get_clientsession(hass)
+        self.store = Store(hass, 1, f"{DOMAIN}_suggestions_{entry.entry_id}.json")
 
         self._last_error: str | None = None
 
@@ -150,6 +152,16 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         self.device_registry: dr.DeviceRegistry | None = None
         self.entity_registry: er.EntityRegistry | None = None
         self.area_registry: ar.AreaRegistry | None = None
+
+    async def _async_load_suggestions(self) -> None:
+        """Load stored suggestions from disk."""
+        stored = await self.store.async_load()
+        if isinstance(stored, dict):
+            self.data.update(stored)
+
+    async def _async_save_suggestions(self) -> None:
+        """Persist current suggestions to disk."""
+        await self.store.async_save(self.data)
 
     # ---------------------------------------------------------------------
     # Utility – options‑first lookup
@@ -184,6 +196,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
         self.device_registry = dr.async_get(self.hass)
         self.entity_registry = er.async_get(self.hass)
         self.area_registry = ar.async_get(self.hass)
+        await self._async_load_suggestions()
 
     async def async_shutdown(self):
         """Handle cleanup when the integration is unloaded."""
@@ -225,6 +238,7 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
             )
             if not picked:
                 self.previous_entities = current
+                await self._async_save_suggestions()
                 return self.data
 
             prompt = await self._build_prompt(picked)
@@ -270,12 +284,14 @@ class AIAutomationCoordinator(DataUpdateCoordinator):
                 )
 
             self.previous_entities = current
+            await self._async_save_suggestions()
             return self.data
 
         except Exception as err:  # noqa: BLE001
             self._last_error = str(err)
             _LOGGER.error("Coordinator fatal error: %s", err)
             self.data["last_error"] = self._last_error
+            await self._async_save_suggestions()
             return self.data
 
     # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- persist AI automation suggestions with `Store`
- reload saved suggestions on startup
- save suggestions after updates or actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b7b171388328bb2ddee65619b1f6